### PR TITLE
Fix patch position and overlap

### DIFF
--- a/biapy/config/config.py
+++ b/biapy/config/config.py
@@ -829,7 +829,10 @@ class Config:
         _C.TEST.DET_POINT_CREATION_FUNCTION = 'peak_local_max'
         # Minimun value to consider a point as a peak. Corresponds to 'threshold_abs' argument of the function
         # 'peak_local_max' of skimage.feature
-        _C.TEST.DET_MIN_TH_TO_BE_PEAK = [0.2]  
+        _C.TEST.DET_MIN_TH_TO_BE_PEAK = [0.2]
+        # Corresponds to 'exclude_border' argument of 'peak_local_max' or 'blob_log' function of skimage. If True it will exclude
+        # peaks from the border of the image to avoid partial detection.
+        _C.TEST.DET_EXCLUDE_BORDER = True
         # Corresponds to 'min_sigma' argument of 'blob_log' function. It is the minimum standard deviation for Gaussian kernel. 
         # Keep this low to detect smaller blobs. The standard deviations of the Gaussian filter are given for each axis as a 
         # sequence, or as a single number, in which case it is equal for all axes.

--- a/biapy/engine/detection.py
+++ b/biapy/engine/detection.py
@@ -162,11 +162,13 @@ class Detection_Workflow(Base_Workflow):
             
             # Find points
             if self.cfg.TEST.DET_POINT_CREATION_FUNCTION == "peak_local_max":
-                pred_coordinates = peak_local_max(pred[...,channel].astype(np.float32), threshold_abs=min_th_peak, exclude_border=True)
+                pred_coordinates = peak_local_max(pred[...,channel].astype(np.float32),
+                                                  threshold_abs=min_th_peak,
+                                                  exclude_border=self.cfg.TEST.DET_EXCLUDE_BORDER)
             else:
                 pred_coordinates = blob_log(pred[...,channel]*255, min_sigma=self.cfg.TEST.DET_BLOB_LOG_MIN_SIGMA, 
                     max_sigma=self.cfg.TEST.DET_BLOB_LOG_MAX_SIGMA, num_sigma=self.cfg.TEST.DET_BLOB_LOG_NUM_SIGMA, 
-                    threshold=min_th_peak, exclude_border=True)
+                    threshold=min_th_peak, exclude_border=self.cfg.TEST.DET_EXCLUDE_BORDER)
                 pred_coordinates = pred_coordinates[:,:3].astype(int) # Remove sigma
 
             # Remove close points per class as post-processing method

--- a/biapy/engine/detection.py
+++ b/biapy/engine/detection.py
@@ -162,11 +162,11 @@ class Detection_Workflow(Base_Workflow):
             
             # Find points
             if self.cfg.TEST.DET_POINT_CREATION_FUNCTION == "peak_local_max":
-                pred_coordinates = peak_local_max(pred[...,channel].astype(np.float32), threshold_abs=min_th_peak, exclude_border=False)
+                pred_coordinates = peak_local_max(pred[...,channel].astype(np.float32), threshold_abs=min_th_peak, exclude_border=True)
             else:
                 pred_coordinates = blob_log(pred[...,channel]*255, min_sigma=self.cfg.TEST.DET_BLOB_LOG_MIN_SIGMA, 
                     max_sigma=self.cfg.TEST.DET_BLOB_LOG_MAX_SIGMA, num_sigma=self.cfg.TEST.DET_BLOB_LOG_NUM_SIGMA, 
-                    threshold=min_th_peak, exclude_border=False)
+                    threshold=min_th_peak, exclude_border=True)
                 pred_coordinates = pred_coordinates[:,:3].astype(int) # Remove sigma
 
             # Remove close points per class as post-processing method


### PR DESCRIPTION
Hello,

I hope you are doing well.
Some input to answer the issue #50.

- Set global position depending on each patch
- Propose to create overlap when detecting by patch

You can see an example of results of the second point here.
![image](https://github.com/BiaPyX/BiaPy/assets/94049435/8791a132-70e5-4c74-aba9-3e015dfaa82a)
The border effect is still present on the border of the *image*. We could solve it by setting the parameter `exclude_border` to `False` [here](https://github.com/ClementCaporal/BiaPy/blob/29ce73bc1b9ad0e10c138ce41c80635ebab1a628/biapy/engine/detection.py#L164-L169)