### PR TITLE
add overlap when splitting z dimension

### DIFF
--- a/biapy/data/data_3D_manipulation.py
+++ b/biapy/data/data_3D_manipulation.py
@@ -838,7 +838,7 @@ def extract_3D_patch_with_overlap_yield(data, vol_shape, axis_order, overlap=(0,
         for j in range(vols):
             z = c+j
             real_start_z = z*step_z
-            real_finish_z = min(real_start_z+step_z, z_dim)
+            real_finish_z = min(real_start_z+step_z+ovz_per_block, z_dim)
             z_vol_info[z] = [real_start_z, real_finish_z]
         list_of_vols_in_z.append(list(range(c,c+vols)))
         c += vols


### PR DESCRIPTION
Should close #50 

Add the `ovz_per_block` when computing the `real_finish_z` when using multiple gpu.


![image](https://github.com/BiaPyX/BiaPy/assets/94049435/8d83c6b3-1917-4e08-8895-2eba11b51a8e)
