### PR TITLE
check if detection is not null when creating dataframe.

### DIFF
--- a/biapy/engine/detection.py
+++ b/biapy/engine/detection.py
@@ -540,11 +540,11 @@ class Detection_Workflow(Base_Workflow):
 
                     c+=1
 
-                    if 'df' not in locals():
-                        df = df_patch.copy()
-                        df['file'] = fname
-                    else:
-                        if df_patch is not None:
+                    if df_patch is not None:
+                        if 'df' not in locals():
+                            df = df_patch.copy()
+                            df['file'] = fname
+                        else:
                             df_patch['file'] = fname
                             df = pd.concat([df, df_patch], ignore_index=True)
 


### PR DESCRIPTION
Small update to close #55 

I propose to check first if `df_patch` is `None` before trying to instanciate the `df`