### PR TITLE
Fix bug in base_workflow.py

### DIFF
--- a/biapy/engine/base_workflow.py
+++ b/biapy/engine/base_workflow.py
@@ -1350,7 +1350,7 @@ class Base_Workflow(metaclass=ABCMeta):
                     pred = self.model_call_func(self._X)
             pred = self.apply_model_activations(pred)
             # Multi-head concatenation
-            if isinstance(p, list):
+            if isinstance(pred, list):
                 pred = torch.cat((pred[0], torch.argmax(pred[1], axis=1).unsqueeze(1)), dim=1)  
             pred = to_numpy_format(pred, self.axis_order_back)  
             if self.cfg.TEST.AUGMENTATION: pred = np.expand_dims(pred, 0)


### PR DESCRIPTION
Received the following traceback in `BiaPy_2D_instance_Segmentation.ipynb` (did not modify the code in the notebook in any way), which prevented the training and inference from completing correctly:

```
Traceback (most recent call last):
  File "/content/BiaPy/main.py", line 51, in <module>
    _biapy.run_job()
  File "/content/BiaPy/biapy/_biapy.py", line 415, in run_job
    self.test()
  File "/content/BiaPy/biapy/_biapy.py", line 159, in test
    self.workflow.test()
  File "/usr/local/lib/python3.10/dist-packages/torch/utils/_contextlib.py", line 115, in decorate_context
    return func(*args, **kwargs)
  File "/content/BiaPy/biapy/engine/base_workflow.py", line 823, in test
    self.process_sample(norm=(X_norm, Y_norm))                        
  File "/content/BiaPy/biapy/engine/instance_seg.py", line 514, in process_sample
    super().process_sample(norm)
  File "/content/BiaPy/biapy/engine/base_workflow.py", line 1353, in process_sample
    if isinstance(p, list):
UnboundLocalError: local variable 'p' referenced before assignment
```