### PR TITLE
C-channel-only instance segmentation

### DIFF
--- a/biapy/config/config.py
+++ b/biapy/config/config.py
@@ -47,7 +47,7 @@ class Config:
 
         ### INSTANCE_SEG
         _C.PROBLEM.INSTANCE_SEG = CN()
-        # Possible options: 'BC', 'BP', 'BD', 'BCM', 'BCD', 'BCDv2', 'Dv2' and 'BDv2'. This variable determines the channels to be created 
+        # Possible options: 'C', 'BC', 'BP', 'BD', 'BCM', 'BCD', 'BCDv2', 'Dv2' and 'BDv2'. This variable determines the channels to be created 
         # based on input instance masks. These option are composed from these individual options:
         #   - 'B' stands for 'Binary segmentation', containing each instance region without the contour. 
         #   - 'C' stands for 'Contour', containing each instance contour. 

--- a/biapy/data/post_processing/post_processing.py
+++ b/biapy/data/post_processing/post_processing.py
@@ -208,7 +208,7 @@ def watershed_by_channels(data, channels, ths={}, remove_before=False, thres_sma
         Binary foreground labels and contours data to apply watershed into. E.g. ``(397, 1450, 2000, 2)``.
 
     channels : str
-        Channel type used. Possible options: ``BC``, ``BCM``, ``BCD``, ``BCDv2``, ``Dv2`` and ``BDv2``.
+        Channel type used. Possible options: ``C``, ``BC``, ``BCM``, ``BCD``, ``BCDv2``, ``Dv2`` and ``BDv2``.
 
     ths : float, optional
         Thresholds to be used on each channel. ``TH_BINARY_MASK`` used in the semantic mask to create watershed seeds;
@@ -257,7 +257,7 @@ def watershed_by_channels(data, channels, ths={}, remove_before=False, thres_sma
         Directory to save watershed output into.
     """
 
-    assert channels in ['BC', 'BCM', 'BCD', 'BCDv2', 'Dv2', 'BDv2', 'BP', 'BD']
+    assert channels in ['C', 'BC', 'BCM', 'BCD', 'BCDv2', 'Dv2', 'BDv2', 'BP', 'BD']
 
     def erode_seed_and_foreground():
         nonlocal seed_map
@@ -306,6 +306,22 @@ def watershed_by_channels(data, channels, ths={}, remove_before=False, thres_sma
         
         res = (1,)+resolution if len(resolution) == 2 else resolution
         semantic = edt.edt(foreground, anisotropy=res, black_border=False, order='C')
+        seed_map = label(seed_map, connectivity=1)
+    elif channels in ["C"]:
+        if ths['TYPE'] == "auto":
+            ths['TH_BINARY_MASK'] = threshold_otsu(1-data[...,0])
+            ths['TH_CONTOUR'] = threshold_otsu(data[...,0])
+            ths['TH_FOREGROUND'] = ths['TH_BINARY_MASK']/2
+        seed_map = (1-data[...,0] > ths['TH_BINARY_MASK']) * (data[...,0] < ths['TH_CONTOUR'])
+        foreground = (1-data[...,0] > ths['TH_FOREGROUND'])
+        
+        if len(seed_morph_sequence) != 0 or erode_and_dilate_foreground:
+            erode_seed_and_foreground()
+        
+        res = (1,)+resolution if len(resolution) == 2 else resolution
+        #semantic = edt.edt(foreground, anisotropy=res, black_border=False, order='C')
+        # use contour channel as input to watershed
+        semantic = -data[...,0]
         seed_map = label(seed_map, connectivity=1)
     elif channels in ["BP"]:
         if ths['TYPE'] == "auto":
@@ -426,7 +442,7 @@ def watershed_by_channels(data, channels, ths={}, remove_before=False, thres_sma
     if save_dir is not None:
         save_tif(np.expand_dims(np.expand_dims(seed_map,-1),0).astype(segm.dtype), save_dir, ["seed_map.tif"], verbose=False)
         save_tif(np.expand_dims(np.expand_dims(semantic,-1),0).astype(np.float32), save_dir, ["semantic.tif"], verbose=False)
-        if channels in ["BC", "BCM", "BCD", "BP"]:
+        if channels in ["C", "BC", "BCM", "BCD", "BP"]:
             save_tif(np.expand_dims(np.expand_dims(foreground,-1),0).astype(np.uint8), save_dir, ["foreground.tif"], verbose=False)
     return segm
 

--- a/biapy/data/pre_processing.py
+++ b/biapy/data/pre_processing.py
@@ -130,8 +130,14 @@ def labels_into_channels(data_mask, mode="BC", fb_mode="outer", save_dir=None):
            Data mask to create the new array from. It is expected to have just one channel. E.g. ``(10, 200, 1000, 1000, 1)``
 
        mode : str, optional
-           Operation mode. Possible values: ``C``, ``BC`` and ``BCD``.  ``C`` corresponds to using only contours, ``BC`` corresponds to
-           using binary segmentation+contour and ``BCD`` stands for binary segmentation+contour+distances.
+           Operation mode. Possible values: ``C``, ``BC``, ``BCM``, ``BCD``, ``BD``, ``BCDv2``, ``Dv2``, ``BDv2`` and ``BP``.
+            - 'B' stands for 'Binary segmentation', containing each instance region without the contour. 
+            - 'C' stands for 'Contour', containing each instance contour. 
+            - 'D' stands for 'Distance', each pixel containing the distance of it to the center of the object. 
+            - 'M' stands for 'Mask', contains the B and the C channels, i.e. the foreground mask. 
+              Is simply achieved by binarizing input instance masks. 
+            - 'Dv2' stands for 'Distance V2', which is an updated version of 'D' channel calculating background distance as well.
+            - 'P' stands for 'Points' and contains the central points of an instance (as in Detection workflow)
 
        fb_mode : str, optional
           Mode of the find_boundaries function from ``scikit-image`` or "dense". More info in:

--- a/biapy/engine/base_workflow.py
+++ b/biapy/engine/base_workflow.py
@@ -1333,7 +1333,7 @@ class Base_Workflow(metaclass=ABCMeta):
                 else:
                     pred, _, _ = load_3d_images_from_dir( self.cfg.PATHS.RESULT_DIR.PER_IMAGE )
                 if pred.ndim == 5:
-                    pred = np.squeeze( pred )
+                    pred = np.squeeze( pred, 0 )
 
             self.after_merge_patches(pred)
             
@@ -1400,7 +1400,7 @@ class Base_Workflow(metaclass=ABCMeta):
                 # load predictions from file
                 pred, _, _ = load_data_from_dir( self.cfg.PATHS.RESULT_DIR.FULL_IMAGE )
                 if pred.ndim == 5:
-                    pred = np.squeeze( pred )
+                    pred = np.squeeze( pred, 0 )
 
             if self.cfg.TEST.ANALIZE_2D_IMGS_AS_3D_STACK:
                 self.all_pred.append(pred)

--- a/biapy/engine/check_configuration.py
+++ b/biapy/engine/check_configuration.py
@@ -223,21 +223,21 @@ def check_configuration(cfg, jobname, check_data_paths=True):
 
     #### Instance segmentation ####
     if cfg.PROBLEM.TYPE == 'INSTANCE_SEG':
-        assert cfg.PROBLEM.INSTANCE_SEG.DATA_CHANNELS in ['BC', 'BCM', 'BCD', 'BCDv2', 'Dv2', 'BDv2', 'BP', 'BD'],\
-            "PROBLEM.INSTANCE_SEG.DATA_CHANNELS not in ['BC', 'BCM', 'BCD', 'BCDv2', 'Dv2', 'BDv2', 'BP', 'BD']"
+        assert cfg.PROBLEM.INSTANCE_SEG.DATA_CHANNELS in ['C', 'BC', 'BCM', 'BCD', 'BCDv2', 'Dv2', 'BDv2', 'BP', 'BD'],\
+            "PROBLEM.INSTANCE_SEG.DATA_CHANNELS not in ['C', 'BC', 'BCM', 'BCD', 'BCDv2', 'Dv2', 'BDv2', 'BP', 'BD']"
         if len(cfg.PROBLEM.INSTANCE_SEG.DATA_CHANNEL_WEIGHTS) != channels_provided:
             raise ValueError("'PROBLEM.INSTANCE_SEG.DATA_CHANNEL_WEIGHTS' needs to be of the same length as the channels selected in 'PROBLEM.INSTANCE_SEG.DATA_CHANNELS'. "
                             "E.g. 'PROBLEM.INSTANCE_SEG.DATA_CHANNELS'='BC' 'PROBLEM.INSTANCE_SEG.DATA_CHANNEL_WEIGHTS'=[1,0.5]. "
                             "'PROBLEM.INSTANCE_SEG.DATA_CHANNELS'='BCD' 'PROBLEM.INSTANCE_SEG.DATA_CHANNEL_WEIGHTS'=[0.5,0.5,1]. "
                             "If 'MODEL.N_CLASSES' > 2 one more weigth need to be provided.")
         if cfg.TEST.POST_PROCESSING.VORONOI_ON_MASK:
-            if cfg.PROBLEM.INSTANCE_SEG.DATA_CHANNELS not in ['BC', 'BCM', 'BCD', 'BCDv2']:
-                raise ValueError("'PROBLEM.INSTANCE_SEG.DATA_CHANNELS' needs to be one between ['BC', 'BCM', 'BCD', 'BCDv2'] "
+            if cfg.PROBLEM.INSTANCE_SEG.DATA_CHANNELS not in ['C', 'BC', 'BCM', 'BCD', 'BCDv2']:
+                raise ValueError("'PROBLEM.INSTANCE_SEG.DATA_CHANNELS' needs to be one between ['C', 'BC', 'BCM', 'BCD', 'BCDv2'] "
                                 "when 'TEST.POST_PROCESSING.VORONOI_ON_MASK' is enabled")
             if not check_value(cfg.TEST.POST_PROCESSING.VORONOI_TH):
                 raise ValueError("'TEST.POST_PROCESSING.VORONOI_TH' not in [0, 1] range")   
-        if cfg.PROBLEM.INSTANCE_SEG.DATA_CHANNELS not in ["BC", "BCM", "BCD", "BP"] and cfg.PROBLEM.INSTANCE_SEG.ERODE_AND_DILATE_FOREGROUND:
-            raise ValueError("'PROBLEM.INSTANCE_SEG.ERODE_AND_DILATE_FOREGROUND' can only be used with 'BC', 'BCM', 'BP' or 'BCD' channels")
+        if cfg.PROBLEM.INSTANCE_SEG.DATA_CHANNELS not in ['C', "BC", "BCM", "BCD", "BP"] and cfg.PROBLEM.INSTANCE_SEG.ERODE_AND_DILATE_FOREGROUND:
+            raise ValueError("'PROBLEM.INSTANCE_SEG.ERODE_AND_DILATE_FOREGROUND' can only be used with 'C', 'BC', 'BCM', 'BP' or 'BCD' channels")
         for morph_operation in cfg.PROBLEM.INSTANCE_SEG.SEED_MORPH_SEQUENCE:
             if morph_operation != "dilate" and morph_operation != "erode":
                 raise ValueError("'PROBLEM.INSTANCE_SEG.SEED_MORPH_SEQUENCE' can only be a sequence with 'dilate' or 'erode' operations. "

--- a/biapy/engine/instance_seg.py
+++ b/biapy/engine/instance_seg.py
@@ -91,7 +91,7 @@ class Instance_Segmentation_Workflow(Base_Workflow):
         self.activations = {}
         if self.cfg.PROBLEM.INSTANCE_SEG.DATA_CHANNELS == "Dv2":
             self.activations = {'0': 'Linear'}
-        elif self.cfg.PROBLEM.INSTANCE_SEG.DATA_CHANNELS in ["BC", "BP", "BCM"]:
+        elif self.cfg.PROBLEM.INSTANCE_SEG.DATA_CHANNELS in ["C", "BC", "BP", "BCM"]:
             self.activations = {':': 'CE_Sigmoid'}
         elif self.cfg.PROBLEM.INSTANCE_SEG.DATA_CHANNELS in ["BDv2", "BD"]:
             self.activations = {'0': 'CE_Sigmoid', '1': 'Linear'}
@@ -132,6 +132,8 @@ class Instance_Segmentation_Workflow(Base_Workflow):
 
         if self.cfg.PROBLEM.INSTANCE_SEG.DATA_CHANNELS == "BC":
             self.metric_names = ["jaccard_index", "jaccard_index"]
+        if self.cfg.PROBLEM.INSTANCE_SEG.DATA_CHANNELS == "C":
+            self.metric_names = ["jaccard_index"]
         elif self.cfg.PROBLEM.INSTANCE_SEG.DATA_CHANNELS == "BCM":
             self.metric_names = ["jaccard_index", "jaccard_index", "jaccard_index"]
         elif self.cfg.PROBLEM.INSTANCE_SEG.DATA_CHANNELS == "BP":

--- a/biapy/engine/metrics.py
+++ b/biapy/engine/metrics.py
@@ -505,6 +505,8 @@ class instance_segmentation_loss():
         elif self.out_channels == "BP":
             loss = self.weights[0]*self.binary_channels_loss(_y_pred[:,0], y_true[:,0])+\
                    self.weights[1]*self.binary_channels_loss(_y_pred[:,1], y_true[:,1])
+        elif self.out_channels == "C":
+            loss = self.binary_channels_loss(_y_pred, y_true)
         # Dv2
         else:
             loss = self.weights[0]*self.distance_channels_loss(_y_pred, y_true)

--- a/biapy/models/attention_unet.py
+++ b/biapy/models/attention_unet.py
@@ -131,7 +131,7 @@ class Attention_U_Net(nn.Module):
 
         # Instance segmentation
         if output_channels is not None:
-            if output_channels == "Dv2":
+            if output_channels in ["C", "Dv2"]:
                 self.last_block = conv(feature_maps[0], 1, kernel_size=1, padding='same')
             elif output_channels in ["BC", "BP"]:
                 self.last_block = conv(feature_maps[0], 2, kernel_size=1, padding='same')

--- a/biapy/models/multiresunet.py
+++ b/biapy/models/multiresunet.py
@@ -278,7 +278,7 @@ class MultiResUnet(torch.nn.Module):
 
         # Instance segmentation
         if output_channels is not None:
-            if output_channels == "Dv2":
+            if output_channels in ["C", "Dv2"]:
                 self.last_block = conv(self.in_filters9, 1, kernel_size=1, padding='same')
             elif output_channels in ["BC", "BP"]:
                 self.last_block = conv(self.in_filters9, 2, kernel_size=1, padding='same')

--- a/biapy/models/resunet++.py
+++ b/biapy/models/resunet++.py
@@ -143,7 +143,7 @@ class ResUNetPlusPlus(nn.Module):
 
         # Instance segmentation
         if output_channels is not None:
-            if output_channels == "Dv2":
+            if output_channels in ["C", "Dv2"]:
                 self.last_block = conv(feature_maps[0], 1, kernel_size=1, padding='same')
             elif output_channels in ["BC", "BP"]:
                 self.last_block = conv(feature_maps[0], 2, kernel_size=1, padding='same')

--- a/biapy/models/resunet.py
+++ b/biapy/models/resunet.py
@@ -124,7 +124,7 @@ class ResUNet(nn.Module):
 
         # Instance segmentation
         if output_channels is not None:
-            if output_channels == "Dv2":
+            if output_channels in ["C", "Dv2"]:
                 self.last_block = conv(feature_maps[0], 1, kernel_size=1, padding='same')
             elif output_channels in ["BC", "BP"]:
                 self.last_block = conv(feature_maps[0], 2, kernel_size=1, padding='same')

--- a/biapy/models/seunet.py
+++ b/biapy/models/seunet.py
@@ -122,7 +122,7 @@ class SE_U_Net(nn.Module):
 
         # Instance segmentation
         if output_channels is not None:
-            if output_channels == "Dv2":
+            if output_channels in ["C", "Dv2"]:
                 self.last_block = conv(feature_maps[0], 1, kernel_size=1, padding='same')
             elif output_channels in ["BC", "BP"]:
                 self.last_block = conv(feature_maps[0], 2, kernel_size=1, padding='same')

--- a/biapy/models/unet.py
+++ b/biapy/models/unet.py
@@ -124,7 +124,7 @@ class U_Net(nn.Module):
 
         # Instance segmentation
         if output_channels is not None:
-            if output_channels == "Dv2":
+            if output_channels in ["C", "Dv2"]:
                 self.last_block = conv(feature_maps[0], 1, kernel_size=1, padding='same')
             elif output_channels in ["BC", "BP"]:
                 self.last_block = conv(feature_maps[0], 2, kernel_size=1, padding='same')

--- a/biapy/models/unetr.py
+++ b/biapy/models/unetr.py
@@ -159,7 +159,7 @@ class UNETR(nn.Module):
 
         # Instance segmentation
         if output_channels is not None:
-            if output_channels == "Dv2":
+            if output_channels in ["C", "Dv2"]:
                 self.last_block = conv(num_filters, 1, kernel_size=1, padding='same')
             elif output_channels in ["BC", "BP"]:
                 self.last_block = conv(num_filters, 2, kernel_size=1, padding='same')


### PR DESCRIPTION
Include a new option for the instance segmentation worfklows where only the contour channel is used. This can be useful for dense segmentation problems such of those in connectomics neurite reconstructions.