### PR TITLE
Fix outdata_shape when C is not last dimension

### DIFF
--- a/biapy/engine/base_workflow.py
+++ b/biapy/engine/base_workflow.py
@@ -1727,12 +1727,13 @@ def insert_patch_into_dataset(data_filename, data_filename_mask, data_shape, out
 
         if 'data' not in locals():
             # Channel dimension should be equal to the number of channel of the prediction
-            out_data_shape = tuple(data_shape)
+            out_data_shape = np.array(data_shape)
             if "C" not in cfg.TEST.BY_CHUNKS.INPUT_IMG_AXES_ORDER:
                 out_data_shape = tuple(out_data_shape) + (p.shape[-1],)
                 out_data_order = cfg.TEST.BY_CHUNKS.INPUT_IMG_AXES_ORDER + "C"
             else:
-                out_data_shape = tuple(out_data_shape[:-1]) + (p.shape[-1],)
+                out_data_shape[cfg.TEST.BY_CHUNKS.INPUT_IMG_AXES_ORDER.index("C")] = 1
+                out_data_shape = tuple(out_data_shape)
                 out_data_order = cfg.TEST.BY_CHUNKS.INPUT_IMG_AXES_ORDER
 
             if file_type == "h5":


### PR DESCRIPTION
Hello,

I hope you are going well. Thank you for the last development!

I had trouble loading my dataset because my axis order is TCZYX and some line assume C is in last position.

This will lead to this kind of error
```python
Traceback (most recent call last):
  File "C:\Users\CHROMS\mambaforge-pypy3\envs\Biapy_env\lib\multiprocessing\process.py", line 314, in _bootstrap
    self.run()
  File "C:\Users\CHROMS\mambaforge-pypy3\envs\Biapy_env\lib\multiprocessing\process.py", line 108, in run
    self._target(*self._args, **self._kwargs)
  File "C:\Users\CHROMS\Documents\github\BiaPy\biapy\engine\base_workflow.py", line 1758, in insert_patch_into_dataset
    data[data_ordered_slices] += p.transpose(transpose_order)
ValueError: non-broadcastable output operand with shape (3,64,482,1) doesn't match the broadcast shape (3,64,482,482)
```

In this PR I propose to only change the C position (where ever it is to 1)

Thank you,

Clément