### PR TITLE
Update central point dilation to use ellipse footprint

### DIFF
--- a/biapy/config/config.py
+++ b/biapy/config/config.py
@@ -115,7 +115,10 @@ class Config:
 
         ### DETECTION
         _C.PROBLEM.DETECTION = CN()
-        # Size of the disk that will be used to dilate the central point created from the CSV file. 0 to not dilate and only create a 3x3 square.
+        # Shape of the ellipse that will be used to dilate the central point created from the CSV file. 0 to not dilate and only create a 3x3 square.
+        # The value is the radius of the ellipse in pixels. If an integer is given, the shape will be a ball with the given side length.
+        # If a list is given, the shape will be a hyperball with the given side lengths.
+        # For example [1, 2, 3] will result in an ellipse with a radius of 1 in the first dimension, 2 in the second and 3 in the third.
         _C.PROBLEM.DETECTION.CENTRAL_POINT_DILATION = 3
         _C.PROBLEM.DETECTION.CHECK_POINTS_CREATED = True
         # Whether to save watershed check files


### PR DESCRIPTION
Hello !

I propose to update the central point dilation in the detection module to use an ellipse footprint instead of a disk. This allows for more flexible and accurate dilation in particular for non isotropic datasets. The new implementation supports both ball-shaped and hyperball-shaped footprints, with the radius specified in pixels for each dimension.

I hope this will help the inference part to be more robust to our user annotation variations (aka points that are not exactly at the center of mass of the cell)

I also propose in this PR to remove the star-shape footprint added by default with the central point. In my view, this would allow a more straight forward use of the central_point_dilatation cfg setting. I moved it inside the case `PROBLEM.DETECTION.CENTRAL_POINT_DILATION == 0` to keep the default 3*3(*3) square

I also updated the config examples (maybe to much verbatim?)