### PR TITLE
Save detected points in patch to a separate file with global coordinates

### DIFF
--- a/biapy/engine/detection.py
+++ b/biapy/engine/detection.py
@@ -1005,6 +1005,15 @@ class Detection_Workflow(Base_Workflow):
             df_patch["axis-1"] = df_patch["axis-1"] + shift[1]
             df_patch["axis-2"] = df_patch["axis-2"] + shift[2]
 
+            # save the detected points in the patch
+            os.makedirs(self.cfg.PATHS.RESULT_DIR.DET_LOCAL_MAX_COORDS_CHECK, exist_ok=True)
+            df_patch.to_csv(
+                os.path.join(
+                    self.cfg.PATHS.RESULT_DIR.DET_LOCAL_MAX_COORDS_CHECK,
+                    os.path.splitext(fname)[0] + "_points_global.csv",
+                )
+            )
+
             return df_patch, fname
 
         return None, None


### PR DESCRIPTION
Hello,

I propose to add new temporary files in the detection workflow.
Patch detection coordinates are already saved but in the patch system coordinate. I propose to add another file 'patch_*_global.csv' that will save the same coordinates but in the image coordinate system space.

Motivation: when a bug arise between local patch detection and "all_points.csv" creation, it is a bit frustrating to try reconstruct the detection by hand. (I just had the case for after a >30h detection ='(  ).