### PR TITLE
Refine chunk_shape calculation to handle NaN values with image.shape

### DIFF
--- a/biapy/data/generators/chunked_test_pair_data_generator.py
+++ b/biapy/data/generators/chunked_test_pair_data_generator.py
@@ -452,7 +452,7 @@ class chunked_test_pair_data_generator(IterableDataset):
                 output_order=self.out_data_order,
                 default_value=np.nan,
             )
-            chunk_shape = tuple([x for x in chunk_shape if not np.isnan(x)]) # type: ignore
+            chunk_shape = tuple([int(val) if not np.isnan(val) else out_data_shape[i] for i, val in enumerate(chunk_shape)])
 
             os.makedirs(self.out_dir, exist_ok=True)
             self.out_file = data_filename


### PR DESCRIPTION
Hello @danifranco thank you for your speed at resolving the issues!
here i propose not to remove the nan value from the chunk shape, but to replace them with the size of the image.
it is necessary otherwise the chunk shape won't have the same shape as the zarr

alternative might be to use `default_value=1`