### PR TITLE
Fix jaccard_index: pass self.ignore_index to JaccardIndex and cast float targets to long

### DIFF
--- a/biapy/engine/metrics.py
+++ b/biapy/engine/metrics.py
@@ -181,11 +181,11 @@ class jaccard_index:
         self.ignore_index = ignore_index if ignore_index != -1 else None
         if self.num_classes > 2:
             self.jaccard = JaccardIndex(
-                task="multiclass", threshold=self.t, num_classes=self.num_classes, ignore_index=ignore_index
+                task="multiclass", threshold=self.t, num_classes=self.num_classes, ignore_index=self.ignore_index
             ).to(self.device, non_blocking=True)
         else:
             self.jaccard = JaccardIndex(
-                task="binary", threshold=self.t, num_classes=self.num_classes, ignore_index=ignore_index
+                task="binary", threshold=self.t, num_classes=self.num_classes, ignore_index=self.ignore_index
             ).to(self.device, non_blocking=True)
 
     def __call__(self, y_pred, y_true):
@@ -224,7 +224,7 @@ class jaccard_index:
                     _y_true = _y_true.squeeze()
                 if len(pd.shape) - 2 == len(_y_true.shape):
                     _y_true = _y_true.unsqueeze(0)
-            iou += self.jaccard(pd, _y_true)
+            iou += self.jaccard(pd, _y_true.long() if _y_true.is_floating_point() else _y_true)
 
         return iou/len(_y_pred)
 


### PR DESCRIPTION
**Problem**

During semantic segmentation inference, IoU calculation failed with `LOSS.IGNORE_INDEX: -1`, a `RuntimeError` was raised by torchmetrics inside `jaccard_index.__call__`:

    RuntimeError: Detected the following values in 'target':
    tensor([0.0000e+00, 3.0707e-41]) but expected only the following
    values [-1].

The crash only occurred on some 3-D volumes (where patch-based tiling produces more patches) and was reproducible on a given image but not observed on all images.

To be perfectly honest, I used Claude Code to try to identify the root cause of the problem and it identified two potential bugs:

```
**Root cause (two bugs)** 

1. `ignore_index` mismatch in `JaccardIndex` construction `jaccard_index.__init__` correctly converts the sentinel value -1 to `None` and stores it in `self.ignore_index`:

       self.ignore_index = ignore_index if ignore_index != -1 else None

   However, the raw `ignore_index` argument (still -1) was forwarded to `JaccardIndex(...)` instead of `self.ignore_index`:

       self.jaccard = JaccardIndex(..., ignore_index=ignore_index)  # -1, not None

   With torchmetrics 1.4.x, passing `ignore_index=-1` causes the validator to accept *only* the value -1 in the target tensor. A float32 target containing {0.0, 1.0} therefore fails validation because 0.0 and 1.0 are not equal to -1.

2. Float32 targets passed to `JaccardIndex` BiaPy converts ground-truth masks to `torch.float32` (via `loss_dtype`) before passing them to the metric. Torchmetrics' `BinaryJaccardIndex` validates that target values are integers in the expected set. When the target is float32, near-zero values that are numerically 0 but represented as subnormal floats (e.g. 3.07e-41) can appear due to memory layout, causing the strict type check to fail with an unexpected value error.

**Fix**

- Pass `self.ignore_index` (which is `None` when `ignore_index == -1`) to both the binary and multiclass `JaccardIndex` constructors so that torchmetrics applies the correct validation logic.
- Cast the target tensor to `long` before the jaccard call when it is floating-point, matching what torchmetrics expects for integer class labels.

```
The patched version of metrics.py does not have problem with calculating IoU on the images it failed on before and the values were in agreement with otherwise calculated IoU. 